### PR TITLE
add mount args for support sles15

### DIFF
--- a/start_samba.sh
+++ b/start_samba.sh
@@ -12,7 +12,7 @@ create_cifs_disk_image() {
 	mkdir -p ${CIFS_DISK_IMAGE_PATH}
 	dd if=/dev/zero of="${CIFS_DISK_IMAGE_PATH}/data.img" count="${CIFS_DISK_IMAGE_SIZE_MB}" bs=1M
 	mkfs.ext4 -F "${CIFS_DISK_IMAGE_PATH}/data.img"
-	mount "${CIFS_DISK_IMAGE_PATH}/data.img" ${EXPORT_PATH}
+	mount -t ext4 -o loop "${CIFS_DISK_IMAGE_PATH}/data.img" ${EXPORT_PATH}
 	chmod 777 "${EXPORT_PATH}"
 }
 


### PR DESCRIPTION
Hi @derekbit, 

When I try deploy https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/cifs-backupstore.yaml on sles 15, the cifs pod will crash with below error
```
mount: mounting /dev/loop0 on /opt/backupstore failed: Invalid argument
```
Submit this PR for fix it, thank you.
